### PR TITLE
Use AD groups for Token Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin
+vault-tokens
+test.txt

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 )
@@ -17,16 +18,24 @@ var (
 	vaultServer = os.Getenv("VAULT_SERVER")
 	vaultToken  = os.Getenv("VAULT_TOKEN")
 	vaultCaPath = os.Getenv("VAULT_CAPATH")
+	configPath  = os.Getenv("CONFIG_PATH")
 )
 
 type userDetails struct {
-	Name string `json:"name"`
+	Name   string   `json:"name"`
+	Groups []string `json:"group"`
 }
 
 func main() {
 
-	if vaultServer == "" || vaultToken == "" || vaultCaPath == "" {
-		fmt.Println("You need to supply both VAULT_TOKEN and VAULT_SERVER and VAULT_CAPATH")
+	if vaultServer == "" || vaultToken == "" || vaultCaPath == "" || configPath == "" {
+		fmt.Println("You need to supply VAULT_TOKEN, VAULT_SERVER, VAULT_CAPATH and CONFIG_PATH")
+		os.Exit(1)
+	}
+
+	allowedGroups, err := readConfig(configPath)
+	if err != nil {
+		fmt.Printf("Could not read csv file: %s", err)
 		os.Exit(1)
 	}
 
@@ -37,21 +46,22 @@ func main() {
 			return
 		}
 
-		bodyBytes, err := ioutil.ReadAll(r.Body)
-		defer r.Body.Close()
-
+		//Filter for the groups defined in the config file
+		groups, err := filterGroups(r.Header.Get("HTTP_X_FORWARDED_GROUPS"), allowedGroups)
 		if err != nil {
 			w.WriteHeader(500)
-			fmt.Fprintf(w, "Failed to read body: %s", err)
+			fmt.Fprintf(w, "Failed to parse Groups: %s", err)
 			return
 		}
-		var body userDetails
-		err = json.Unmarshal(bodyBytes, &body)
-
-		if err != nil {
-			w.WriteHeader(400)
-			fmt.Fprintf(w, "Failed to parse body: %s", err)
+		if len(groups) == 0 {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "User has no allowed groups")
 			return
+		}
+
+		user := userDetails{
+			Name:   r.Header.Get("HTTP_X_FORWARDED_USER"),
+			Groups: groups,
 		}
 
 		vaultClient, err := newVaultClient(vaultServer, vaultCaPath)
@@ -60,21 +70,21 @@ func main() {
 			fmt.Fprintf(w, "Failed to create vault client: %s", err)
 			return
 		}
-		token, err := generateToken(vaultClient, body)
+		token, err := generateToken(vaultClient, user)
 		if err != nil {
 			w.WriteHeader(500)
 			fmt.Fprintf(w, "Failed to get token: %s", err)
 			return
 		}
 
+		// Return the Vault reponse containing the token
 		var binBuf bytes.Buffer
 		resp, err := json.Marshal(token)
 		if err != nil {
 			w.WriteHeader(500)
-			fmt.Fprintf(w, "Failed to get parse vault reponse: %s", err)
+			fmt.Fprintf(w, "Failed to parse vault reponse: %s", err)
 			return
 		}
-
 		binary.Write(&binBuf, binary.BigEndian, resp)
 		w.Write(binBuf.Bytes())
 
@@ -85,7 +95,11 @@ func main() {
 func generateToken(client *vault.Client, user userDetails) (*vault.Secret, error) {
 	auth := client.Auth()
 	tokenAuth := auth.Token()
-	secret, err := tokenAuth.Create(&vault.TokenCreateRequest{})
+	secret, err := tokenAuth.Create(&vault.TokenCreateRequest{
+		TTL:         "60",
+		DisplayName: user.Name,
+		Policies:    user.Groups,
+	})
 	if err != nil {
 		return &vault.Secret{}, err
 	}
@@ -104,4 +118,37 @@ func newVaultClient(server string, ca string) (*vault.Client, error) {
 		return &vault.Client{}, err
 	}
 	return client, nil
+}
+
+func readConfig(configPath string) ([]string, error) {
+	//Open CSV File
+	f, err := os.Open(configPath)
+	if err != nil {
+		return []string{}, err
+	}
+	defer f.Close()
+
+	// Read File into a Variable
+	allowedGroups, err := csv.NewReader(f).Read()
+	if err != nil {
+		return []string{}, err
+	}
+
+	return allowedGroups, nil
+}
+
+func filterGroups(groupString string, allowedGroups []string) ([]string, error) {
+	groups := strings.Split(groupString, "|")
+
+	filteredGroups := []string{}
+
+	for _, g := range groups {
+		for _, a := range allowedGroups {
+			if a == g {
+				filteredGroups = append(filteredGroups, a)
+			}
+		}
+	}
+
+	return filteredGroups, nil
 }


### PR DESCRIPTION
This gets your group from the headers, checks if the group is allowed for vault by checking a config file. If you belong to a valid group it will create a token for you with your groups policy applied to it
  